### PR TITLE
Mejora el diseño del ModalEditor: ajusta el ancho y el tamaño del tex…

### DIFF
--- a/src/components/ModalEditor.jsx
+++ b/src/components/ModalEditor.jsx
@@ -120,10 +120,10 @@ export function ModalEditor({ subject, onClose, onSave }) {
 
   return (
     <div className="fixed top-0 left-0 w-full h-full z-40 pointer-events-none backdrop-blur-xs bg-black/30">
-      <div className="absolute top-[20%] left-1/2 transform -translate-x-1/2 w-full max-w-md z-50 pointer-events-auto">
+      <div className="absolute top-[20%] left-1/2 transform -translate-x-1/2 w-[80%] max-w-md sm:max-w-[80%] z-50 pointer-events-auto">
         <div className="bg-white p-6 rounded-xl shadow-2xl border">
           <div className="flex justify-between items-center mb-4">
-            <h2 className="text-2xl font-semibold">Editar asignatura</h2>
+            <h2 className="text-xl sm:text-2xl font-semibold">Editar asignatura</h2>
             <button onClick={onClose} className="text-gray-500 hover:text-black text-xl font-bold">
               <X size={30} />
             </button>
@@ -158,7 +158,7 @@ export function ModalEditor({ subject, onClose, onSave }) {
               onChange={handleChange}
               className="input-field"
             />
-            <div className="flex justify-center gap-5">
+            <div className="flex flex-col items-center sm:flex-row justify-center gap-5">
               <div className='flex flex-row gap-2 items-center'>
                 <label className="text-gray-700">Hora Inicio:</label>
                 <TimePicker value={edited.horaInicio} onChange={handleTimeChange} />


### PR DESCRIPTION
…to en el encabezado, y modifica la disposici
This pull request updates the `ModalEditor` component to improve its responsiveness and layout, especially for smaller screens. The changes focus on making the modal and its contents adapt better to different screen sizes.

**Responsive design improvements:**

* The modal width is now set to `80%` on all screens, with a maximum width of `md` on default and `80%` on small screens, making it more adaptable to various device sizes. (`src/components/ModalEditor.jsx`, [src/components/ModalEditor.jsxL123-R126](diffhunk://#diff-224c4bbb3e9e8a63b4ca46c29cfb7518da7b27dcceb415c8d52109f8f8d45cb3L123-R126))
* The modal title font size is now responsive, using `text-xl` on small screens and `text-2xl` on larger screens. (`src/components/ModalEditor.jsx`, [src/components/ModalEditor.jsxL123-R126](diffhunk://#diff-224c4bbb3e9e8a63b4ca46c29cfb7518da7b27dcceb415c8d52109f8f8d45cb3L123-R126))
* The button group layout is now a column on small screens and a row on larger screens, improving usability on mobile devices. (`src/components/ModalEditor.jsx`, [src/components/ModalEditor.jsxL161-R161](diffhunk://#diff-224c4bbb3e9e8a63b4ca46c29cfb7518da7b27dcceb415c8d52109f8f8d45cb3L161-R161))ón de los elementos en la sección de hora de inicio.